### PR TITLE
Fix broken compose file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ services:
       - 69:69
     volumes:
       - /<path to isos>:/iventoy/iso
+      - /<path to config>:/iventoy/data
+      - /<path to logs>:/iventoy/log
 ```
 
 Not necessary to expose all the listed ports.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iventoy
 
-A docker image running iventoy.
+A Docker image running [iventoy](https://www.iventoy.com).
 
 A github actions workflow runs daily to check if their is a new release.
 
@@ -8,21 +8,25 @@ A github actions workflow runs daily to check if their is a new release.
 
 ## Docker Compose
 
+This does not work with rootless Docker.  The container must be run as root.
+
 ```yaml
 ---
 version: '3.9'
 services:
   iventoy:
-    volumes:
-      - <mount>:<folder>
+    image: ziggyds/iventoy:latest
+    container_name: iventoy
+    restart: always
+    privileged: true #must be true
     ports:
       - 26000:26000
       - 16000:16000
       - 10809:10809
       - 67:67
       - 69:69
-    image: ziggyds/iventoy:latest
-    restart: unless-stopped
+    volumes:
+      - /<path to isos>:/iventoy/iso
 ```
 
 Not necessary to expose all the listed ports.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
 # iventoy
 
-A docker image running iventoy. 
+A docker image running iventoy.
 
 A github actions workflow runs daily to check if their is a new release.
 
-https://hub.docker.com/r/ziggyds/iventoy
+<https://hub.docker.com/r/ziggyds/iventoy>
 
 ## Docker Compose
-````
+
+```yaml
 ---
 version: '3.9'
 services:
   iventoy:
-   volumes:
-     - <mount>:<folder>
+    volumes:
+      - <mount>:<folder>
     ports:
-      - 26000:26000 
-      - 16000:16000 
+      - 26000:26000
+      - 16000:16000
       - 10809:10809
       - 67:67
       - 69:69
     image: ziggyds/iventoy:latest
     restart: unless-stopped
-````
+```
+
 Not necessary to expose all the listed ports.
-https://www.iventoy.com/en/doc_portnum.html
+<https://www.iventoy.com/en/doc_portnum.html>


### PR DESCRIPTION
This fixes the broken indentation on the docker-compose file in the README. It also specifies the language (yaml) and formats the README itself with [markdownlint](https://github.com/DavidAnson/markdownlint).