### PR TITLE
Add tag network_mode: "host" so iVentoy can be used outside internal …

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ services:
     container_name: iventoy
     restart: always
     privileged: true #must be true
+    network_mode: "host"
     ports:
       - 26000:26000
       - 16000:16000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,24 +5,19 @@ services:
     container_name: iventoy
     restart: always
     privileged: true #must be true
+    network_mode: "host"
     ports:
-      - 16000:16000
       - 26000:26000
+      - 16000:16000
+      - 10809:10809
+      - 67:67/udp
+      - 69:69/udp
     volumes:
       - isos:/app/iso
       - config:/app/data
+      - /<path to logs>:/app/log
     environment:
-      - AUTO_START_PXE=true
-    
-
-  build:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      labels:
-        IVENTOY: 1.0.19
-      args:
-        IVENTOY: 1.0.19
+      - AUTO_START_PXE=true # optional, true by default
 
 volumes:
   isos:


### PR DESCRIPTION
I have added the tag `network_mode: "host"` to the docker-compose.yaml so the iVentoy container can be used outside the internal docker network.